### PR TITLE
Add compatibility with EDD 3.0

### DIFF
--- a/includes/functions.php
+++ b/includes/functions.php
@@ -299,7 +299,7 @@ function edd_email_reports_weekly_best_selling_downloads() {
 			'number'     => - 1,
 			'start_date' => '6 days ago 00:00',
 			'end_date'   => 'now',
-			'status'     => 'complete',
+			'status'     => 'publish', // EDD 3.0 will auto convert to 'complete'.
 		)
 	);
 

--- a/includes/functions.php
+++ b/includes/functions.php
@@ -113,9 +113,6 @@ function edd_email_reports_cold_selling_downloads() {
 
 	$last_sale_dates = array();
 
-	/** @var EDD_Logging $edd_logs */
-	global $edd_logs;
-
 	if ( ! empty( $downloads ) ) {
 
 		foreach ( $downloads as $download ) {
@@ -134,6 +131,9 @@ function edd_email_reports_cold_selling_downloads() {
 					$last_sale_dates[ $download->post_title ] = $result[0]->date_created;
 				}
 			} else {
+				/** @var EDD_Logging $edd_logs */
+				global $edd_logs;
+
 				$result = $edd_logs->get_connected_logs(
 					array(
 						'post_parent'    => $download->ID,

--- a/includes/functions.php
+++ b/includes/functions.php
@@ -109,27 +109,27 @@ function edd_email_reports_cold_selling_downloads() {
 		'posts_per_page' => - 1,
 	);
 
-	$result = get_posts( $args );
+	$downloads = get_posts( $args );
 
 	$last_sale_dates = array();
 
-	/* @var EDD_Logging $edd_logs */
+	/** @var EDD_Logging $edd_logs */
 	global $edd_logs;
 
-	if ( ! empty( $result ) ) {
+	if ( ! empty( $downloads ) ) {
 
-		foreach ( $result as $download ) {
+		foreach ( $downloads as $download ) {
 
-			$result = $edd_logs->get_connected_logs(
+			$logs = $edd_logs->get_connected_logs(
 				array(
-					'post_parent'    => $download->ID,
-					'log_type'       => 'sale',
-					'posts_per_page' => 1,
+					'object_id' => $download->ID,
+					'type'      => 'sale',
+					'number'    => 1,
 				)
 			);
 
-			if ( ! empty( $result ) ) {
-				$last_sale_dates[ $download->post_title ] = $result[0]->post_date;
+			if ( ! empty( $logs ) ) {
+				$last_sale_dates[ $download->post_title ] = $logs[0]->date_created;
 			}
 		}
 
@@ -284,7 +284,7 @@ function edd_email_reports_weekly_best_selling_downloads() {
 			'number'     => - 1,
 			'start_date' => '6 days ago 00:00',
 			'end_date'   => 'now',
-			'status'     => 'publish',
+			'status'     => 'complete',
 		)
 	);
 

--- a/includes/functions.php
+++ b/includes/functions.php
@@ -120,16 +120,31 @@ function edd_email_reports_cold_selling_downloads() {
 
 		foreach ( $downloads as $download ) {
 
-			$logs = $edd_logs->get_connected_logs(
-				array(
-					'object_id' => $download->ID,
-					'type'      => 'sale',
-					'number'    => 1,
-				)
-			);
+			if ( function_exists( 'edd_get_orders' ) ) {
+				$result = edd_get_orders( array(
+					'type'       => 'sale',
+					'status__in' => edd_get_gross_order_statuses(),
+					'product_id' => $download->ID,
+					'orderby'    => 'date_created',
+					'order'      => 'DESC',
+					'number'     => 1
+				) );
 
-			if ( ! empty( $logs ) ) {
-				$last_sale_dates[ $download->post_title ] = $logs[0]->date_created;
+				if ( ! empty( $result[0] ) ) {
+					$last_sale_dates[ $download->post_title ] = $result[0]->date_created;
+				}
+			} else {
+				$result = $edd_logs->get_connected_logs(
+					array(
+						'post_parent'    => $download->ID,
+						'log_type'       => 'sale',
+						'posts_per_page' => 1,
+					)
+				);
+
+				if ( ! empty( $result ) ) {
+					$last_sale_dates[ $download->post_title ] = $result[0]->post_date;
+				}
 			}
 		}
 


### PR DESCRIPTION
Note: I have updated parameters accepted by `EDD_Logging::get_connected_logs()`. However, I was not able to test them as no sales logs are stored since [9f41aa0](https://github.com/easydigitaldownloads/easy-digital-downloads/commit/9f41aa0d6ba9f7fffade8ce739156563657af1d7#diff-9ff79b78ebccf1faf39ce8b144c5532068eb495f1876e674af6349b6b14525c3). Maybe this section should be removed?