### PR TITLE
Issue/17

### DIFF
--- a/includes/functions.php
+++ b/includes/functions.php
@@ -365,7 +365,7 @@ function edd_email_reports_sort_best_selling_downloads( $a, $b ) {
 	if ( $a['earnings'] == $b['earnings'] ) {
 		return 0;
 	}
-	return ( $a['earnings'] < $b['earnings'] ) ? -1 : 1;
+	return ( $a['earnings'] < $b['earnings'] ) ? 1 : -1;
 }
 
 /**

--- a/includes/functions.php
+++ b/includes/functions.php
@@ -362,7 +362,7 @@ function edd_email_reports_weekly_best_selling_downloads() {
  * @return int   Returns either -1, 0, or 1, depending on the comparison of $a and $b.
  */
 function edd_email_reports_sort_best_selling_downloads( $a, $b ) {
-	if ( $a == $b ) {
+	if ( $a['earnings'] == $b['earnings'] ) {
 		return 0;
 	}
 	return ( $a['earnings'] < $b['earnings'] ) ? -1 : 1;

--- a/includes/functions.php
+++ b/includes/functions.php
@@ -359,10 +359,13 @@ function edd_email_reports_weekly_best_selling_downloads() {
  * @param  array $a The item being sorted.
  * @param  array $b The item being sorted against.
  *
- * @return [type]    [description]
+ * @return int   Returns either -1, 0, or 1, depending on the comparison of $a and $b.
  */
 function edd_email_reports_sort_best_selling_downloads( $a, $b ) {
-	return $a['earnings'] < $b['earnings'];
+	if ( $a == $b ) {
+		return 0;
+	}
+	return ( $a['earnings'] < $b['earnings'] ) ? -1 : 1;
 }
 
 /**


### PR DESCRIPTION
Fixes #17 deprecated notice in PHP 8

Proposed Changes:
1. Changed callback function `edd_email_reports_sort_best_selling_downloads()` used for `usort()` to return an integer, as per function spec. Equality returns 0, less than returns -1, greater than returns 1.